### PR TITLE
Catch fatal exception in ServerGroup.py for missing sub license

### DIFF
--- a/imperva_sdk/ServerGroup.py
+++ b/imperva_sdk/ServerGroup.py
@@ -204,4 +204,7 @@ class ServerGroup(MxObject):
   def get_db_service(self, Name=None):
     return self._connection.get_db_service(Name=Name, Site=self._Site, ServerGroup=self.Name)
   def get_all_db_services(self):
-    return self._connection.get_all_db_services(Site=self._Site, ServerGroup=self.Name)
+    try:
+      return self._connection.get_all_db_services(Site=self._Site, ServerGroup=self.Name)
+    except:
+      return []


### PR DESCRIPTION
Avoids fatal error for a lack of sub license: {'description': 'This feature is currently not licensed.', 'error-code': 'IMP-10129'} which does not appear to need to be fatal.

```
POST https://172.21.x.x:8083/SecureSphere/api/v1/auth/session
  header - Authorization: Basic x
  header - Content-Type: application/json
GET https://172.21.x.x:8083/SecureSphere/api/v1/administration/version
  header - Content-Type: application/json
  header - Cookie: JSESSIONID=x; SSOSESSIONID=x
GET https://172.21.x.x:8083/SecureSphere/api/v1/administration/challenge
  header - Content-Type: application/json
  header - Cookie: JSESSIONID=x; SSOSESSIONID=x
GET https://172.21.x.x:8083/SecureSphere/api/v1/conf/sites
  header - Content-Type: application/json
  header - Cookie: JSESSIONID=x;SSOSESSIONID=x
...
...
GET https://172.21.x.x:8083/SecureSphere/api/v1/conf/dbServices/Default Site/waf-production-b
  header - Content-Type: application/json
  header - Cookie: JSESSIONID=x;SSOSESSIONID=x
Traceback (most recent call last):
  File "/Users/x/git/sec-imperva-config/src/./config.py", line 74, in <module>
    export = mx.export_to_json(Discard=['MatchCriteria', 'ApplyTo'])
  File "/Users/x/git/sec-imperva-config/src/venv/lib/python3.9/site-packages/imperva_sdk/MxConnection.py", line 2152, in export_to_json
    site_dict = dict(site)
  File "/Users/x/git/sec-imperva-config/src/venv/lib/python3.9/site-packages/imperva_sdk/core.py", line 43, in __iter__
    iters[child_title].append(dict(child))
  File "/Users/x/git/sec-imperva-config/src/venv/lib/python3.9/site-packages/imperva_sdk/core.py", line 40, in __iter__
    children = get_all_function()
  File "/Users/x/git/sec-imperva-config/src/venv/lib/python3.9/site-packages/imperva_sdk/ServerGroup.py", line 198, in get_all_db_services
    return self._connection.get_all_db_services(Site=self._Site, ServerGroup=self.Name)
  File "/Users/x/git/sec-imperva-config/src/venv/lib/python3.9/site-packages/imperva_sdk/MxConnection.py", line 411, in get_all_db_services
    return DbService._get_all_db_services(connection=self, ServerGroup=ServerGroup, Site=Site)
  File "/Users/x/git/sec-imperva-config/src/venv/lib/python3.9/site-packages/imperva_sdk/DbService.py", line 100, in _get_all_db_services
    res = connection._mx_api('GET', '/conf/dbServices/%s/%s' % (Site, ServerGroup))
  File "/Users/x/git/sec-imperva-config/src/venv/lib/python3.9/site-packages/imperva_sdk/MxConnection.py", line 257, in _mx_api
    raise MxException("MX returned errors - %s" % str(error_message))
imperva_sdk.core.MxException: MX returned errors - [{'description': 'This feature is currently not licensed.', 'error-code': 'IMP-10129'}]
DELETE https://172.21.x.x:8083/SecureSphere/api/v1/auth/session
  header - Content-Type: application/json
  header - Cookie: JSESSIONID=x;SSOSESSIONID=x
```
  
Can be recreated with example code from: https://imperva.github.io/imperva-sdk-python/examples.html#example-4-create-mx-configuration-from-json
```
 import imperva_sdk
import json
import pprint

# Connect to MX and export configuration
mx = imperva_sdk.MxConnection("10.0.0.1")
export = mx.export_to_json(Discard=['MatchCriteria', 'ApplyTo'])

# Pretty print the JSON with pprint
export_pretty = pprint.pformat(json.loads(export)).replace('    ', ' ')
print export_pretty
```